### PR TITLE
Centralizar conteúdo

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,7 +1,7 @@
 /*Importando fonte*/
 @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 /*Reset*/
-*{
+* {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
@@ -12,6 +12,16 @@ body{
     color: #fff;
     background-color: #040404;
 }
+
+/* Centralizar conteúdo */
+
+html {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
 /*Header*/
 header{
     display: flex;


### PR DESCRIPTION
Em alguns dispositivos com tela de altura superior, o conteúdo perdia um pouco do foco por causa do grande espaçamento inferior. Centralizando o conteúdo, esse problema é resolvido, tendo um preenchimento mais proporcional da tela.